### PR TITLE
JSON version > 2.3.0 due to CVE CVE-2020-10663

### DIFF
--- a/fontcustom.gemspec
+++ b/fontcustom.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_dependency "json", "~>1.4"
+  gem.add_dependency "json", ">=2.3.0"
   gem.add_dependency "thor", "~>0.14"
   gem.add_dependency "listen", ">=1.0","<4.0"
 


### PR DESCRIPTION
https://www.ruby-lang.org/en/news/2020/03/19/json-dos-cve-2020-10663/